### PR TITLE
query input repopulates from history menu, same endpoint input

### DIFF
--- a/client/Components/HistoryDisplay.jsx
+++ b/client/Components/HistoryDisplay.jsx
@@ -4,21 +4,41 @@ import { useStateValue } from '../Context';
 import * as types from '../Constants/actionTypes';
 
 
-const handleClick = (event) => {
-  event.preventDefault();
-  //delete div
-  let element = document.getElementById(event.target.id);
-  element.parentNode.removeChild(element);
-  //delete from DB by id
-  const id = Number(event.target.id)
-  db.history
-  .delete(id)
-  .then(console.log('deleted ', id));
-}
 
 const HistoryDisplay = () => {
   const [{ queriesHistory, query, queryGQLError }, dispatch] = useStateValue();
   const [localQH, setLocalQH] = useState([]);
+
+  const handleClickDelete = (event) => {
+    event.preventDefault();
+    //delete div
+    const element = document.getElementById(event.target.id);
+    element.parentNode.removeChild(element);
+    //delete from DB by id
+    const id = Number(event.target.id);
+    db.history
+      .delete(id)
+      .then(console.log('deleted ', id));
+  }
+
+  const handleClickEdit = (event) => {
+    event.preventDefault();
+    const id = Number(event.target.id);
+    db.history
+      .get(id)
+      .then((query) => {
+        console.log('query in handleClickEdit ', query.query)
+        dispatch({
+          type: types.GET_QUERY,
+          historyTextValue: query.query,
+          endpoint: query.endpoint
+        })
+      })
+      .then(() => {
+        const inputField = document.querySelector('#endpoint-field input');
+        inputField.value = '';
+      })
+  }
 
   useEffect(() => {
     db.history
@@ -34,11 +54,10 @@ const HistoryDisplay = () => {
   }, [query, queryGQLError]);
 
 
-  console.log('queriesHistory, before render: ', queriesHistory);
-  // const historyList = queriesHistory.map(el => <li id="el.id">{el.query}</li>);
-  const historyList = localQH.map(el => <li id={el.id}>{el.query}<button id={el.id} onClick={() => handleClick(event)}>delete</button><button id={el.id}>edit</button></li>);
+  // console.log('queriesHistory, before render: ', queriesHistory);
+  const historyList = localQH.map(el => <li id={el.id}>{el.query}<button id={el.id} onClick={() => handleClickDelete(event)}>delete</button><button id={el.id} onClick={() => handleClickEdit(event)}>edit</button></li>);
 
-  console.log('historyList => list of queries as LIs ', historyList);
+  // console.log('historyList => list of queries as LIs ', historyList);
   return (
     <div>
       <ul id="history-display">

--- a/client/Components/QueryInput.jsx
+++ b/client/Components/QueryInput.jsx
@@ -25,17 +25,29 @@ query ditto {
 
 
 const QueryInput = () => {
+  const [{ endpoint, historyTextValue }, dispatch] = useStateValue();
+  console.log('rendering')
   const [textValue, setTextValue] = useState(exampleQuery);
-  const [{ endpoint }, dispatch] = useStateValue();
+  if (historyTextValue !== '' && textValue !== historyTextValue) setTextValue(historyTextValue)
+  // console.log('historyTextValue in queryInput ', historyTextValue)
+  console.log('textValue ', textValue)
   const [newAPIEndpoint, setNewAPIEndpoint] = useState('');
 
   // this fetch chain/handleSubmit should be added into a different file
   // and imported. might be a heavy lift because of all the variables
   const handleSubmit = () => {
+
+    // if there's a value in api endpoint, replace endpoint.
+    // if it's empty, use endpoint in context state
+    console.log('testing fetch, code written after DB addition');
+    const urlToSend = newAPIEndpoint || endpoint;
+
     // send textValue to Dexie db
     db.history.put({
       query: textValue,
+      endpoint: urlToSend
     })
+    
       .then(() => console.log('sent to db'))
       // .then(() => {
       //   db.history
@@ -47,12 +59,8 @@ const QueryInput = () => {
       //       });
       //     });
       // })
-    ;
+      ;
 
-    // if there's a value in api endpoint, replace endpoint.
-    // if it's empty, use endpoint in context state
-    console.log('testing fetch, code written after DB addition');
-    const urlToSend = newAPIEndpoint || endpoint;
     // prevent refresh
     event.preventDefault();
 

--- a/client/Constants/actionTypes.js
+++ b/client/Constants/actionTypes.js
@@ -3,3 +3,4 @@ export const SUBMIT_ENDPOINT = 'SUBMIT_ENDPOINT';
 export const RESET_STATE = 'RESET_STATE';
 export const GQL_ERROR = 'GQL_ERROR';
 export const UPDATE_HISTORY = 'UPDATE_HISTORY';
+export const GET_QUERY = 'GET_QUERY';

--- a/client/Context.js
+++ b/client/Context.js
@@ -31,6 +31,7 @@ const initialState = {
   // need to instantiate url or else query without a user input will not run
   // queries stored in db
   queriesHistory: [],
+  historyTextValue: ''
 };
 
 const reducer = (state, action) => {
@@ -77,6 +78,13 @@ const reducer = (state, action) => {
         ...state,
         queriesHistory: action.queriesHistory,
       };
+      case types.GET_QUERY:
+        console.log('in GET_QUERY')
+        return {
+          ...initialState,
+          historyTextValue: action.historyTextValue,
+          endpoint: action.endpoint
+        };
     default:
       return state;
   }

--- a/client/db.js
+++ b/client/db.js
@@ -2,7 +2,7 @@ import Dexie from 'dexie';
 
 const db = new Dexie('historyDb');
 db.version(1).stores({
-  history: '++id, query',
+  history: '++id, query, endpoint',
 });
 
 export default db;


### PR DESCRIPTION
Co-authored-by: Will Robinson <wrobinson91@gmail.com>
Co-authored-by: Sophie Nye <sophie.nye@gmail.com>