### PR TITLE
reset button working; edit repopulates endpoint field

### DIFF
--- a/client/Components/HistoryDisplay.jsx
+++ b/client/Components/HistoryDisplay.jsx
@@ -53,14 +53,8 @@ const HistoryDisplay = (props) => {
         const inputField = document.querySelector(`#endpoint-field[input-field-tab-id ="${currentTabID}"] input`);
         console.log('found input: ', inputField);
         inputField.value = foundQuery.endpoint;
-        // const inputFields = document.querySelectorAll('#endpoint-field input');
-        // // clears fields for all input field attribues. but endpoint value at component level still takes in what was in endpoint field beforehand
-        // inputFields.forEach((el) => {
-        //   el.value = '';
-        // });
-        // inputFields.value = '';
       })
-      .catch(e => console.log('Error searching DB.', e));
+      .catch(e => console.log('Error searching DB.'));
   };
 
   const onDelete = (queryId) => {

--- a/client/Components/HistoryDisplay.jsx
+++ b/client/Components/HistoryDisplay.jsx
@@ -74,7 +74,7 @@ const HistoryDisplay = (props) => {
       <section id="history-header">History</section>
       <button id="clear-history" type="button" onClick={clearHistory}>Clear History</button>
       <ul id="history-list">
-        {localQH.map((pastQueries, idx) => <HistoryListItem key={`history-li-${idx}`} query={pastQueries} id={pastQueries.id} onDelete={onDelete} onEdit={onEdit} />)}
+        {localQH.map((pastQueries, idx) => <HistoryListItem key={`history-li-${idx}`} queryText={pastQueries.query} id={pastQueries.id} endpoint={pastQueries.endpoint} onDelete={onDelete} onEdit={onEdit} />)}
       </ul>
     </section>
   );

--- a/client/Components/HistoryDisplay.jsx
+++ b/client/Components/HistoryDisplay.jsx
@@ -47,16 +47,20 @@ const HistoryDisplay = (props) => {
           endpoint: foundQuery.endpoint,
           currentTabID,
         });
+        return foundQuery;
       })
-      .then(() => {
-        const inputFields = document.querySelectorAll('#endpoint-field input');
-        // clears fields for all input field attribues. but endpoint value at component level still takes in what was in endpoint field beforehand
-        inputFields.forEach((el) => {
-          el.value = '';
-        });
+      .then((foundQuery) => {
+        const inputField = document.querySelector(`#endpoint-field[input-field-tab-id ="${currentTabID}"] input`);
+        console.log('found input: ', inputField);
+        inputField.value = foundQuery.endpoint;
+        // const inputFields = document.querySelectorAll('#endpoint-field input');
+        // // clears fields for all input field attribues. but endpoint value at component level still takes in what was in endpoint field beforehand
+        // inputFields.forEach((el) => {
+        //   el.value = '';
+        // });
         // inputFields.value = '';
       })
-      .catch(e => console.log('Error searching DB.'));
+      .catch(e => console.log('Error searching DB.', e));
   };
 
   const onDelete = (queryId) => {
@@ -74,7 +78,7 @@ const HistoryDisplay = (props) => {
   return (
     <section id="history-display">
       <section id="history-header">History</section>
-      <button id="clear-history" type="button" onClick={clearHistory}>Clear Database</button>
+      <button id="clear-history" type="button" onClick={clearHistory}>Clear History</button>
       <ul id="history-list">
         {localQH.map((pastQueries, idx) => <HistoryListItem key={`history-li-${idx}`} query={pastQueries} id={pastQueries.id} onDelete={onDelete} onEdit={onEdit} />)}
       </ul>

--- a/client/Components/MiniComponents/HistoryListItem.jsx
+++ b/client/Components/MiniComponents/HistoryListItem.jsx
@@ -19,8 +19,7 @@ const HistoryListItem = (props) => {
         onMouseEnter={() => toggleHover(true)}
         onMouseLeave={() => toggleHover(false)}
       >
-        {`Endpoint: ${query.endpoint}
-        Path: ${path}`}
+        {`Endpoint: ${query.endpoint}\nPath: ${path}`}
 
         {isHovering && (
           <span id="button-hover">

--- a/client/Components/MiniComponents/HistoryListItem.jsx
+++ b/client/Components/MiniComponents/HistoryListItem.jsx
@@ -4,10 +4,10 @@ import React, { useState } from 'react';
 const HistoryListItem = (props) => {
   const [isHovering, toggleHover] = useState(false);
   const {
-    id, query, onDelete, onEdit,
+    id, queryText, endpoint, onDelete, onEdit,
   } = props;
 
-  const pathRegex = query.query.match(/(?<=path:\W*\")\S*(?=\")/gi);
+  const pathRegex = queryText.match(/(?<=path:\W*\")\S*(?=\")/gi);
   const path = pathRegex ? pathRegex[0] : 'invalid';
   // console.log('rendering a list item');
   return (
@@ -19,7 +19,7 @@ const HistoryListItem = (props) => {
         onMouseEnter={() => toggleHover(true)}
         onMouseLeave={() => toggleHover(false)}
       >
-        {`Endpoint: ${query.endpoint}\nPath: ${path}`}
+        {`Endpoint: ${endpoint}\nPath: ${path}`}
 
         {isHovering && (
           <span id="button-hover">

--- a/client/Components/QueryInput.jsx
+++ b/client/Components/QueryInput.jsx
@@ -130,12 +130,14 @@ const QueryInput = (props) => {
               onClick={() => {
                 dispatch({
                   type: types.RESET_STATE,
+                  currentTab: stateTabReference,
                 });
                 // after reseting state, reset endpoint field to empty string. in state,
                 // it will be POKEAPI
 
                 // vanilla DOM manipulation was the best way to change the input field value
-                const inputField = document.querySelector('#endpoint-field input');
+                // only resets current tab's endpoint field
+                const inputField = document.querySelector(`#endpoint-field[input-field-tab-id ="${stateTabReference}"] input`);
                 inputField.value = '';
                 // reset textValue field to exampleQuery
                 setTextValue(exampleQuery);

--- a/client/Context.js
+++ b/client/Context.js
@@ -109,6 +109,7 @@ const reducer = (state, action) => {
         // this might not be needed below
         endpointHistory: {
           ...state.endpointHistory,
+          [action.currentTab]: 'https://pokeapi.co/api/v2/pokemon/',
         },
         // TAB INDICIES NOT NEEDED RIGHT NOW
         // tabIndices: {

--- a/client/StyleSheets/App.scss
+++ b/client/StyleSheets/App.scss
@@ -32,6 +32,8 @@ body {
         "historyDisplay reactTabs";
     font: $font-stack;
     background-color: $background-color;
+    // NOT SURE WHAT ELSE THE BELOW MIGHT CAUSE, BUT THIS FIXES WHITESPACE ON BOTTOM
+    overflow: hidden;
 }
 
 %input-fields {


### PR DESCRIPTION
-- reset button resets global endpoint state, and the endpoint history for the current tab
--edit button repopulates endpoint field
--edited history list item to take props for endpoint and queryText instead of entire query obj found in DB
-- added "overflow: hidden;" CSS prop to #app to fix random whitespace at bottom. NOT SURE WHAT ELSE THIS MIGHT EFFECT